### PR TITLE
pirateflix is broken; this PR fixes it

### DIFF
--- a/src/helpers/get.js
+++ b/src/helpers/get.js
@@ -2,7 +2,7 @@ import fetch from 'isomorphic-fetch';
 
 // TODO: will come from setup
 const config = {
-  url: 'http://thepiratebay.se',
+  url: 'http://thepiratebay.org',
 };
 
 export default async function get({ search, page }) {


### PR DESCRIPTION
I noticed pirateflix recently stopped working. After a bit of digging, the problem turned out to be a broken URL. Here's the fix.